### PR TITLE
Check feature test macros exist before using

### DIFF
--- a/src/agrpc/detail/config.hpp
+++ b/src/agrpc/detail/config.hpp
@@ -63,7 +63,7 @@
 // Try-catch
 #ifndef AGRPC_TRY
 
-#if __cpp_exceptions >= 199711L
+#if defined(__cpp_exceptions) && (__cpp_exceptions >= 199711L)
 #define AGRPC_TRY try
 #define AGRPC_CATCH(...) catch (__VA_ARGS__)
 #else

--- a/src/agrpc/detail/math.hpp
+++ b/src/agrpc/detail/math.hpp
@@ -20,7 +20,7 @@
 
 #include <agrpc/detail/config.hpp>
 
-#if __cpp_lib_bitops >= 201907L
+#if defined(__cpp_lib_bitops) && (__cpp_lib_bitops >= 201907L)
 #include <bit>
 #endif
 
@@ -34,7 +34,7 @@ constexpr auto maximum(T a, T b) noexcept
     return (a < b) ? b : a;
 }
 
-#if __cpp_lib_bitops >= 201907L
+#if defined(__cpp_lib_bitops) && (__cpp_lib_bitops >= 201907L)
 constexpr std::size_t floor_log2(std::size_t x) noexcept
 {
     constexpr auto SIZE_T_BIT_COUNT_MINUS_ONE = sizeof(std::size_t) * CHAR_BIT - std::size_t{1};


### PR DESCRIPTION
This avoids warnings from `-Wundef` if a feature isn't available, which is a fairly common warning to enable