### PR TITLE
Add PROTOC and GRPC_PLUGIN arguments to asio_grpc_protobuf_generate

### DIFF
--- a/test/cmake/superbuild/src/CMakeLists.txt
+++ b/test/cmake/superbuild/src/CMakeLists.txt
@@ -53,6 +53,11 @@ target_link_libraries(target-option PRIVATE asio-grpc::asio-grpc-standalone-asio
 asio_grpc_protobuf_generate(
     GENERATE_GRPC GENERATE_MOCK_CODE
     TARGET target-option
+
+    # Optional: override host tools (useful for cross-compilation)
+    # PROTOC "/usr/bin/protoc"
+    # GRPC_PLUGIN "/usr/bin/grpc_cpp_plugin"
+
     OUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/target"
     PROTOS "${CMAKE_CURRENT_SOURCE_DIR}/proto/target.proto")
 # /* [asio_grpc_protobuf_generate-example] */


### PR DESCRIPTION
In cross-compilation (e.g., building from a native host for a different target platform like ARM or Windows), the binaries specified by `$<TARGET_FILE:protobuf::protoc>` and `$<TARGET_FILE:gRPC::grpc_cpp_plugin>` are built for the target platform and cannot be executed on the host to generate code during the build process.
For example:
- A protoc binary compiled for ARM cannot run on an x86 host, causing build failures.
- Similarly, the gRPC plugin for the target platform may be incompatible with the host, which prevents code generation.

Now we can use a custom executable:
```code
if(CMAKE_CROSSCOMPILING)
    find_program(PROTOBUF_PROTOC_EXECUTABLE protoc REQUIRED)
    find_program(GRPC_PLUGIN_EXECUTABLE grpc_cpp_plugin REQUIRED)
else()
    set(PROTOBUF_PROTOC_EXECUTABLE $<TARGET_FILE:protobuf::protoc>)
    set(GRPC_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
endif()

asio_grpc_protobuf_generate(
    GENERATE_GRPC
    PROTOC "${PROTOBUF_PROTOC_EXECUTABLE}"
    GRPC_PLUGIN "${GRPC_PLUGIN_EXECUTABLE}"
    OUT_DIR "${PROTO_OUTPUT}"
    OUT_VAR GENERATED_PROTO_SRCS
    IMPORT_DIRS "${PROTO_OUTPUT}"
    PROTOS "${PROTO_FILE}"
    EXTRA_ARGS ${EXTRA_PROTO_ARGS})
```